### PR TITLE
Update feedstock for v0.5.0-rc2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "docs-versions-menu" %}
-{% set version = "0.5.0rc1" %}
+{% set version = "0.5.0rc2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/docs_versions_menu-{{ version }}.tar.gz
-  sha256: 404d720f28cac80791244021713807a2593ad94c14116acf6247eed788624091
+  sha256: ef976254e1451ec8b7b082c39c070df1a379652c874ef4da2f4774d20837a48c
 
 build:
   noarch: python


### PR DESCRIPTION
I'm manually creating this PR since the `regro-cf-auotick-bot` didn't pick up on the PyPI Release.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
